### PR TITLE
Fixing multiplayer issue when we can't find the player who launched a missile

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -791,7 +791,7 @@ function vehicles.object_no_drive(entity, dtime, def)
 	--stop
 		entity.object:setvelocity(vec_stop)
 		--animation
-		if moving_anim ~= nil and entity.moving and not hovering then
+		if entity.moving_anim ~= nil and entity.moving and not hovering then
 			entity.object:set_animation(stand_anim, 20, 0)
 			entity.moving = false
 		end

--- a/init.lua
+++ b/init.lua
@@ -41,11 +41,13 @@ minetest.register_entity("vehicles:missile", {
 			self.object:remove()
 		end)
 		local player = self.launcher
-		local dir = player:get_look_dir();
-		local vec = {x=dir.x*16,y=dir.y*16,z=dir.z*16}
-		local yaw = player:get_look_yaw();
-		self.object:setyaw(yaw+math.pi/2)
-		self.object:setvelocity(vec)
+        if player ~= nil then
+            local dir = player:get_look_dir();
+            local vec = {x=dir.x*16,y=dir.y*16,z=dir.z*16}
+            local yaw = player:get_look_yaw();
+            self.object:setyaw(yaw+math.pi/2)
+            self.object:setvelocity(vec)
+        end
 		local pos = self.object:getpos()
 		local vec = self.object:getvelocity()
 		minetest.add_particlespawner({


### PR DESCRIPTION
This seems to fix issue #25 for us.  Open to feedback on the approach used and possible unintended consequences. 