### PR TITLE
Fix:when can't find the player who launched a missile

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -46,6 +46,10 @@ minetest.register_entity("vehicles:missile", {
 			return
 		end
 		local dir = player:get_look_dir();
+		if dir == nil then
+			self.object:remove()
+			return
+		end
 		local vec = {x=dir.x*16,y=dir.y*16,z=dir.z*16}
 		local yaw = player:get_look_yaw();
 		self.object:setyaw(yaw+math.pi/2)


### PR DESCRIPTION
```
2017-07-18 21:15:53: ACTION[Server]: b leaves game. List of players: a 
2017-07-18 21:15:53: WARNING[Server]: Deprecated call to get_look_yaw, use get_look_horizontal instead
2017-07-18 21:15:53: WARNING[Server]: Deprecated call to get_look_yaw, use get_look_horizontal instead
2017-07-18 21:15:53: WARNING[Server]: Deprecated call to get_look_yaw, use get_look_horizontal instead
2017-07-18 21:15:53: WARNING[Server]: Deprecated call to get_look_yaw, use get_look_horizontal instead
2017-07-18 21:15:53: WARNING[Server]: Deprecated call to get_look_yaw, use get_look_horizontal instead
2017-07-18 21:15:54: WARNING[Server]: Deprecated call to get_look_yaw, use get_look_horizontal instead
2017-07-18 21:15:54: WARNING[Server]: Deprecated call to get_look_yaw, use get_look_horizontal instead
2017-07-18 21:15:54: WARNING[Server]: Deprecated call to get_look_yaw, use get_look_horizontal instead
2017-07-18 21:15:54: WARNING[Server]: Deprecated call to get_look_yaw, use get_look_horizontal instead
2017-07-18 21:15:54: WARNING[Server]: Deprecated call to get_look_yaw, use get_look_horizontal instead
2017-07-18 21:15:54: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'vehicles' in callback luaentity_Step(): /home/zaoqi/.minetest/mods/vehicles/init.lua:49: attempt to index local 'dir' (a nil value)
2017-07-18 21:15:54: ERROR[Main]: stack traceback:
2017-07-18 21:15:54: ERROR[Main]: 	/home/zaoqi/.minetest/mods/vehicles/init.lua:49: in function </home/zaoqi/.minetest/mods/vehicles/init.lua:39>
2017-07-18 21:15:54: ACTION[Server]: a leaves game. List of players: 
```