### PR TITLE
MT 5 mod.conf

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,5 +1,0 @@
-default
-tnt
-dye
-stairs?
-creative?

--- a/description.txt
+++ b/description.txt
@@ -1,2 +1,0 @@
-A mod that adds an api for cars, planes, and other vehicles.
-Several vehicles are included in the mod.

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,4 @@
 name = vehicles
+description = A mod that adds an api for cars, planes, and other vehicles. Several vehicles are included in the mod.
+depends = default, tnt, dye
+optional_depends = stairs, creative


### PR DESCRIPTION
mod.conf format changed in MT 5
Since MT5 API has been used, there is no need to consider supporting MT0.4