### PR TITLE
Allows to get vehicles in low health conditions

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -745,7 +745,7 @@ function vehicles.on_punch(self, puncher)
 	end
 	if not self.driver then return end
 	local creative_mode = creative and creative.is_enabled_for and creative.is_enabled_for(self.driver:get_player_name())
-	if self.driver == puncher and (hp == self.hp_max-5 or hp == self.hp_max or creative_mode) then
+	if self.driver == puncher then
 		local name = self.object:get_luaentity().name
 		local pos = self.object:getpos()
 		minetest.env:add_item(pos, name.."_spawner")


### PR DESCRIPTION
If a vehicle cannot be turned into an item when its health is low, it will cause a lot of inconvenience to the player. In addition, the vehicle also needs to be repaired. From the most convenient point of view, "turn into an item and put it back into the backpack" is the most convenient Convenient repair method.

Note: If you are unwilling to accept this PR, you can consider adding a tool to restore health to the vehicle (it can be repaired by consuming iron or mese).