### PR TITLE
Detect if the object is dying rather than dead.

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -735,9 +735,9 @@ function vehicles.explodinate(ent, radius)
 	end)
 end
 
-function vehicles.on_punch(self, puncher)
+function vehicles.on_punch(self, puncher, time_from_last_punch, tool_capabilities, direction, damage)
 	local hp = self.object:get_hp()
-	if hp == 0 then
+	if (hp - damage) < 1 then
 		if self.driver then
 			vehicles.object_detach(self, self.driver, {x=1, y=0, z=1})
 		end


### PR DESCRIPTION
The engine doesn't call on_punch when the object is already dead. The necessary fix is to accept the damage param and use it to predict if this call kills the object (resolves #61).